### PR TITLE
chore: add CODEOWNERS file to define code ownership

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# All code currently owned by mauvehed
+*     @mauvehed


### PR DESCRIPTION
Introduce a CODEOWNERS file to specify that all code is currently owned by the user @mauvehed. This ensures clear ownership and responsibility for code maintenance and reviews, streamlining the collaboration process within the team.
