### PR TITLE
add GitHub Actions workflow for tagging releases

### DIFF
--- a/.github/workflows/build-version.yml
+++ b/.github/workflows/build-version.yml
@@ -1,0 +1,22 @@
+name: Tag Release
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Install Dependencies
+        run: yarn install
+
+      - name: Generate Build Version
+        run: yarn generate-version
+
+      - name: Build Application
+        run: yarn build

--- a/docs/DEVELOPERS.md
+++ b/docs/DEVELOPERS.md
@@ -84,6 +84,18 @@ We use a simple variation of Git and GitHub Flow for branch control.
 git checkout -b develop
 ```
 
+### Switch to a develop branch (every other time)
+
+```bash
+git checkout develop
+```
+
+#### Ensure develop is in sync with main
+
+```bash
+git merge main
+```
+
 #### Create a feature branch from develop
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "generate-version": "node scripts/generate-build-version.js",
-    "build": "yarn generate-version && nuxt build",
+    "build": "nuxt build",
     "dev": "nuxt dev",
     "generate": "nuxt generate",
     "preview": "nuxt preview",


### PR DESCRIPTION
ci(build-version.yml): add GitHub Actions workflow for tagging releases

Create a new GitHub Actions workflow to automate the process of tagging
releases. The workflow triggers on push, pull request, and manual
dispatch events. It checks out the repository, installs dependencies,
generates a build version, and builds the application.

chore(package.json): remove redundant generate-version script from build command

The `generate-version` script is now handled separately in the GitHub
Actions workflow, making it unnecessary to include it in the local
build command. This change streamlines the build process and ensures
version generation is consistently managed by the CI pipeline.

## Summary by Sourcery

Implement a GitHub Actions workflow to automate release tagging and streamline the build process by removing the local 'generate-version' script. Update developer documentation to reflect changes in branch management.

CI:
- Add a GitHub Actions workflow to automate the process of tagging releases, triggered by push, pull request, and manual dispatch events.

Documentation:
- Update DEVELOPERS.md to include instructions for switching to and syncing the develop branch with main.

Chores:
- Remove the redundant 'generate-version' script from the build command in package.json as it is now handled by the CI workflow.